### PR TITLE
Remove no_backticks rule.

### DIFF
--- a/.coffeelint.json
+++ b/.coffeelint.json
@@ -45,9 +45,6 @@
         "value": 1,
         "level": "error"
     },
-    "no_backticks": {
-        "level": "error"
-    },
     "no_debugger": {
         "level": "error"
     },


### PR DESCRIPTION
This conflicts with using coffeescript with ES6 modules (ember-cli).
