### PR TITLE
Add rubocop-rspec to default config and instructions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+# Include additional cops for linting RSpec specs. Make sure you have the
+# `rubocop-rspec` gem installed.
+require: rubocop-rspec
+
 # For a full list of configuration options and defaults, see Rubocop's
 # annotated default configuration file at
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
@@ -97,3 +101,12 @@ Style/Blocks:
 Style/IfUnlessModifier:
   Exclude:
     - 'config/initializers/*'
+
+# The top-level `describe` call should reference a class or module that is
+# under test. This is not the case in some kinds of integration tests that are
+# not tied to a particular class or module. Disable this cop in those cases.
+RSpec/DescribeClass:
+  Exclude:
+    - spec/requests/**/*
+    - spec/features/**/*
+    - spec/views/**/*

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ special `.rubocop.yml` file in the root of your project.
 Include Rubocop in your Gemfile:
 
     gem 'rubocop', group: 'development'
+    gem 'rubocop-rspec', group: 'development'
 
 Optionally install the Rake task to run RuboCop by copying `rubocop.rake` into
 your Rails tasks directory (`lib/tasks`).


### PR DESCRIPTION
This adds [nevir/rubocop-rspec](https://github.com/nevir/rubocop-rspec) to the default config.
