### PR TITLE
Rubocop uses Style/BlockDelimiters instead of Style/Blocks since 0.30.0

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -91,7 +91,7 @@ Style/CaseEquality:
 # delimiters. This is fine rule, except in case of RSpec tests, where the
 # `expect { ... }.to` is idiomatically written across multiple lines. Disable
 # only in specs.
-Style/Blocks:
+Style/BlockDelimiters:
   Exclude:
     - spec/**/*_spec.rb
 


### PR DESCRIPTION
Changed to name of the cop so it keeps working with Rubocop >=0.30.