### PR TITLE
Set default multiline operation formatting to indented

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -102,6 +102,10 @@ Style/IfUnlessModifier:
   Exclude:
     - 'config/initializers/*'
 
+# Ensure indented style is used for multiline operations, not aligned style.
+Style/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
 # The top-level `describe` call should reference a class or module that is
 # under test. This is not the case in some kinds of integration tests that are
 # not tied to a particular class or module. Disable this cop in those cases.


### PR DESCRIPTION
This avoids having to change the indentation aftr de left hand side
of the first line is changed. Also, the "aligned" style had multiple
variations, which can be a source of confusion.

This fixes #6 .