### PR TITLE
Ensure bundler_audit ignores are passed to task runner

### DIFF
--- a/ruby/bundler_audit.rake
+++ b/ruby/bundler_audit.rake
@@ -11,5 +11,5 @@ task :bundler_audit do
     else
       []
     end
-  Bundler::Audit::CLI.start(['check'])
+  Bundler::Audit::CLI.start(['check', *ignores])
 end


### PR DESCRIPTION
Got a RuboCop "useless variable assignment" warning on this, which pointed me into the right direction.