### PR TITLE
Update rubocop defaults

### DIFF
--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -101,6 +101,14 @@ Style/IfUnlessModifier:
   Exclude:
     - 'config/initializers/*'
 
+# Prefer indented multiline style (less maintenance hassle).
+Style/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+
+# Prefer indented multiline style (less maintenance hassle).
+Style/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
 # Ensure indented style is used for multiline operations, not aligned style.
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -7,12 +7,12 @@ require: rubocop-rspec
 # https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
 AllCops:
-
   # Exclude automatically generated files.
   Exclude:
     - db/schema.rb
     - bin/**/*
     - script/**/*
+  TargetRubyVersion: 2.3
 
 Rails:
   Enabled: true

--- a/ruby/.rubocop.yml
+++ b/ruby/.rubocop.yml
@@ -14,9 +14,8 @@ AllCops:
     - bin/**/*
     - script/**/*
 
-  # Run Rails-specific cops. Remove this line if you want to use Rubocop in a
-  # non-Rails project.
-  RunRailsCops: true
+Rails:
+  Enabled: true
 
 Style/CollectionMethods:
   # Mapping from undesired method to desired_method


### PR DESCRIPTION
On adding RuboCop to a project, I had some issues with the current defaults. First two commits address these.

The last two commits are a bit more opiniated, but for me, these would improve my first-run experience. 